### PR TITLE
feat: make consistency level configurable, default LOCAL_QUORUM

### DIFF
--- a/tap_cassandra/client.py
+++ b/tap_cassandra/client.py
@@ -88,9 +88,13 @@ class CassandraConnector:
         """
         
         if self._profile is None:
+            consistency_levels = {
+                True: ConsistencyLevel.LOCAL_ONE,
+                False: ConsistencyLevel.LOCAL_QUORUM,
+            }
             self._profile = ExecutionProfile(
                 retry_policy=RetryPolicy(),
-                consistency_level=ConsistencyLevel.LOCAL_QUORUM,
+                consistency_level=consistency_levels[self.config.get('allow_local_one_consistency')],
                 serial_consistency_level=ConsistencyLevel.LOCAL_SERIAL,
                 request_timeout=self.config.get('request_timeout'),
                 row_factory=dict_factory,

--- a/tap_cassandra/tap.py
+++ b/tap_cassandra/tap.py
@@ -99,6 +99,13 @@ class TapCassandra(SQLTap):
             default=False,
             description="When set to `True` skipping partitions when faced ReadTimout or ReadFailure errors.",
         ),
+        th.Property(
+            "allow_local_one_consistency",
+            th.BooleanType,
+            required=False,
+            default=False,
+            description="When set to `True`, uses LOCAL_ONE consistency level instead of LOCAL_QUORUM. Useful when a replica is unavailable.",
+        ),
     ).to_dict()
 
     @property


### PR DESCRIPTION
Add consistency_level config option to allow overriding the Cassandra read consistency level. Defaults to LOCAL_QUORUM for backward compatibility. Set to LOCAL_ONE to allow reads when a replica is unavailable.